### PR TITLE
Feat : add audit info when query groups

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.event.ChallengeCancelEvent;
 import sleppynavigators.studyupbackend.domain.group.Group;
 import sleppynavigators.studyupbackend.domain.user.User;
 import sleppynavigators.studyupbackend.domain.event.SystemEvent;
@@ -48,7 +49,9 @@ public class ChallengeService {
 
         Challenge challenge = challengeRepository.save(request.toEntity(user, group));
 
-        SystemEvent event = new ChallengeCreateEvent(user.getUserProfile().username(), challenge.getDetail().title(),
+        SystemEvent event = new ChallengeCreateEvent(
+                user.getUserProfile().username(),
+                challenge.getDetail().title(),
                 groupId);
         systemEventPublisher.publish(event);
 
@@ -64,7 +67,11 @@ public class ChallengeService {
             throw new ForbiddenContentException();
         }
 
-        // TODO: need to publish system event
+        SystemEvent event = new ChallengeCancelEvent(
+                user.getUserProfile().username(),
+                challenge.getDetail().title(),
+                challenge.getGroup().getId());
+        systemEventPublisher.publish(event);
 
         challengeRepository.deleteById(challengeId);
     }

--- a/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
@@ -51,10 +51,10 @@ public class GroupService {
     public GroupResponse createGroup(Long creatorId, GroupCreationRequest request) {
         User creator = userRepository.findById(creatorId).orElseThrow(EntityNotFoundException::new);
         Group savedGroup = groupRepository.save(request.toEntity(creator));
-        
+
         Bot bot = new Bot(savedGroup);
         botRepository.save(bot);
-        
+
         return GroupResponse.fromEntity(savedGroup);
     }
 
@@ -75,7 +75,7 @@ public class GroupService {
         });
     }
 
-    public GroupResponse getInvitedGroup(Long groupId, Long invitationId) {
+    public GroupInvitationResponse getInvitation(Long groupId, Long invitationId) {
         GroupInvitation invitation = groupInvitationRepository.findById(invitationId)
                 .orElseThrow(EntityNotFoundException::new);
 
@@ -83,7 +83,7 @@ public class GroupService {
             throw new InvalidPayloadException();
         }
 
-        return GroupResponse.fromEntity(invitation.getGroup());
+        return GroupInvitationResponse.fromEntity(invitation);
     }
 
     @Transactional
@@ -107,10 +107,10 @@ public class GroupService {
 
         User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         group.addMember(user);
-        
+
         SystemEvent event = new UserJoinEvent(user.getUserProfile().username(), groupId);
         systemEventPublisher.publish(event);
-        
+
         return GroupResponse.fromEntity(group);
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/application/user/UserService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/user/UserService.java
@@ -6,10 +6,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.chat.ChatMessage;
 import sleppynavigators.studyupbackend.domain.group.Group;
 import sleppynavigators.studyupbackend.domain.user.User;
 import sleppynavigators.studyupbackend.exception.database.EntityNotFoundException;
 import sleppynavigators.studyupbackend.infrastructure.challenge.TaskRepository;
+import sleppynavigators.studyupbackend.infrastructure.chat.ChatMessageRepository;
 import sleppynavigators.studyupbackend.infrastructure.group.GroupRepository;
 import sleppynavigators.studyupbackend.infrastructure.user.UserRepository;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
@@ -24,6 +26,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
     private final TaskRepository taskRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     public UserResponse getUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
@@ -32,7 +35,9 @@ public class UserService {
 
     public GroupListResponse getGroups(Long userId) {
         List<Group> groups = groupRepository.findAllByMembersUserId(userId);
-        return GroupListResponse.fromEntities(groups);
+        List<ChatMessage> chatMessages = chatMessageRepository
+                .findLatestMessagesPerGroupByGroupIds(groups.stream().map(Group::getId).toList());
+        return GroupListResponse.fromEntities(groups, chatMessages);
     }
 
     public UserTaskListResponse getTasks(Long userId) {

--- a/src/main/java/sleppynavigators/studyupbackend/application/user/UserService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/user/UserService.java
@@ -7,9 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
 import sleppynavigators.studyupbackend.domain.group.Group;
+import sleppynavigators.studyupbackend.domain.user.User;
+import sleppynavigators.studyupbackend.exception.database.EntityNotFoundException;
 import sleppynavigators.studyupbackend.infrastructure.challenge.TaskRepository;
 import sleppynavigators.studyupbackend.infrastructure.group.GroupRepository;
+import sleppynavigators.studyupbackend.infrastructure.user.UserRepository;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
+import sleppynavigators.studyupbackend.presentation.user.dto.response.UserResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse;
 
 @Service
@@ -17,8 +21,14 @@ import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskLi
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserService {
 
+    private final UserRepository userRepository;
     private final GroupRepository groupRepository;
     private final TaskRepository taskRepository;
+
+    public UserResponse getUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        return UserResponse.fromEntity(user);
+    }
 
     public GroupListResponse getGroups(Long userId) {
         List<Group> groups = groupRepository.findAllByMembersUserId(userId);

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -31,6 +31,8 @@ import sleppynavigators.studyupbackend.exception.business.ForbiddenContentExcept
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Challenge extends TimeAuditBaseEntity {
 
+    private static final long MODIFIABLE_PERIOD_HOUR = 24L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -76,7 +78,8 @@ public class Challenge extends TimeAuditBaseEntity {
 
     public boolean canModify(User user) {
         // We might change it to allow edits even if the user is not the owner of the challenge.
-        return isOwner(user);
+        return isOwner(user) &&
+                LocalDateTime.now().isBefore(createdAt.plusHours(MODIFIABLE_PERIOD_HOUR));
     }
 
     public boolean canAccess(User user) {

--- a/src/main/java/sleppynavigators/studyupbackend/domain/chat/ChatMessage.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/chat/ChatMessage.java
@@ -44,19 +44,23 @@ public class ChatMessage {
 
     public static ChatMessage fromUser(Long userId, Long groupId, String content) {
         return ChatMessage.builder()
-            .senderId(userId)
-            .groupId(groupId)
-            .content(content)
-            .senderType(SenderType.USER)
-            .build();
+                .senderId(userId)
+                .groupId(groupId)
+                .content(content)
+                .senderType(SenderType.USER)
+                .build();
     }
 
     public static ChatMessage fromBot(Long botId, Long groupId, String content) {
         return ChatMessage.builder()
-            .senderId(botId)
-            .groupId(groupId)
-            .content(content)
-            .senderType(SenderType.BOT)
-            .build();
+                .senderId(botId)
+                .groupId(groupId)
+                .content(content)
+                .senderType(SenderType.BOT)
+                .build();
+    }
+
+    public boolean isBelongTo(Long groupId) {
+        return this.groupId.equals(groupId);
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/chat/SystemMessageTemplate.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/chat/SystemMessageTemplate.java
@@ -6,7 +6,8 @@ public enum SystemMessageTemplate {
     USER_JOIN_MESSAGE_TEMPLATE("%s님이 그룹에 참여했습니다."),
     USER_LEAVE_MESSAGE_TEMPLATE("%s님이 그룹을 나갔습니다."),
     CHALLENGE_CREATE_MESSAGE_TEMPLATE("%s님이 '%s' 챌린지를 생성했습니다."),
-    CHALLENGE_COMPLETE_MESSAGE_TEMPLATE("%s님이 '%s' 챌린지를 완료했습니다.");
+    CHALLENGE_COMPLETE_MESSAGE_TEMPLATE("%s님이 '%s' 챌린지를 완료했습니다."),
+    CHALLENGE_CANCEL_MESSAGE_TEMPLATE("%s님이 '%s' 챌린지를 취소했습니다.");
 
     private final String messageFormat;
 
@@ -24,6 +25,7 @@ public enum SystemMessageTemplate {
             case USER_LEAVE -> event.generateMessage(USER_LEAVE_MESSAGE_TEMPLATE);
             case CHALLENGE_CREATE -> event.generateMessage(CHALLENGE_CREATE_MESSAGE_TEMPLATE);
             case CHALLENGE_COMPLETE -> event.generateMessage(CHALLENGE_COMPLETE_MESSAGE_TEMPLATE);
+            case CHALLENGE_CANCEL -> event.generateMessage(CHALLENGE_CANCEL_MESSAGE_TEMPLATE);
         };
     }
 } 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/common/TimeAuditBaseEntity.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/common/TimeAuditBaseEntity.java
@@ -17,9 +17,9 @@ public abstract class TimeAuditBaseEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/common/UserAndTimeAuditBaseEntity.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/common/UserAndTimeAuditBaseEntity.java
@@ -20,11 +20,11 @@ public abstract class UserAndTimeAuditBaseEntity extends TimeAuditBaseEntity {
 
     @CreatedBy
     @Column(updatable = false)
-    private Long createdBy;
+    protected Long createdBy;
 
     @LastModifiedBy
     @Column
-    private Long updatedBy;
+    protected Long updatedBy;
 
     public Long getLastModifier() {
         return Optional.ofNullable(updatedBy).orElse(createdBy);

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/ChallengeCancelEvent.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/ChallengeCancelEvent.java
@@ -1,0 +1,21 @@
+package sleppynavigators.studyupbackend.domain.event;
+
+import sleppynavigators.studyupbackend.domain.chat.SystemMessageTemplate;
+
+public record ChallengeCancelEvent(String userName, String challengeName, Long groupId) implements SystemEvent {
+
+    @Override
+    public SystemEventType getType() {
+        return SystemEventType.CHALLENGE_CANCEL;
+    }
+
+    @Override
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    @Override
+    public String generateMessage(SystemMessageTemplate template) {
+        return template.format(userName, challengeName);
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/SystemEventType.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/SystemEventType.java
@@ -4,5 +4,6 @@ public enum SystemEventType {
     USER_JOIN,
     USER_LEAVE,
     CHALLENGE_CREATE,
-    CHALLENGE_COMPLETE
+    CHALLENGE_COMPLETE,
+    CHALLENGE_CANCEL,
 }

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/chat/ChatMessageRepository.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/chat/ChatMessageRepository.java
@@ -1,12 +1,22 @@
 package sleppynavigators.studyupbackend.infrastructure.chat;
 
+import java.util.List;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import sleppynavigators.studyupbackend.domain.chat.ChatMessage;
 
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, ObjectId> {
-    
+
     Page<ChatMessage> findByGroupIdOrderByCreatedAtDesc(Long groupId, Pageable pageable);
+
+    @Aggregation(pipeline = {
+            "{ $match: { 'groupId': { $in: ?0 } } }",
+            "{ $sort: { 'createdAt': -1 } }",
+            "{ $group: { '_id': '$groupId', 'latestMessage': { $first: '$$ROOT' } } }",
+            "{ $replaceRoot: { 'newRoot': '$latestMessage' } }"
+    })
+    List<ChatMessage> findLatestMessagesPerGroupByGroupIds(List<Long> groupIds);
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeController.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +28,17 @@ import sleppynavigators.studyupbackend.presentation.common.SuccessResponse;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
+
+    @DeleteMapping("/{challengeId}")
+    @Operation(summary = "챌린지 취소", description = "챌린지를 취소합니다.")
+    public ResponseEntity<SuccessResponse<Void>> deleteChallenge(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long challengeId
+    ) {
+        Long userId = userPrincipal.userId();
+        challengeService.cancelChallenge(userId, challengeId);
+        return ResponseEntity.ok(new SuccessResponse<>(null));
+    }
 
     @GetMapping("/{challengeId}/tasks")
     @Operation(summary = "챌린지 테스크 목록 조회", description = "챌린지의 테스크 목록을 조회합니다.")

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/GroupController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/GroupController.java
@@ -70,10 +70,10 @@ public class GroupController {
 
     @GetMapping("/{groupId}/invitations/{invitationId}")
     @Operation(summary = "그룹 초대 조회", description = "그룹 초대를 조회합니다.")
-    public ResponseEntity<SuccessResponse<GroupResponse>> getInvitation(
+    public ResponseEntity<SuccessResponse<GroupInvitationResponse>> getInvitation(
             @PathVariable Long groupId, @PathVariable Long invitationId
     ) {
-        GroupResponse response = groupService.getInvitedGroup(groupId, invitationId);
+        GroupInvitationResponse response = groupService.getInvitation(groupId, invitationId);
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupInvitationResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupInvitationResponse.java
@@ -4,10 +4,22 @@ import jakarta.validation.constraints.NotBlank;
 import org.jetbrains.annotations.NotNull;
 import sleppynavigators.studyupbackend.domain.group.invitation.GroupInvitation;
 
-public record GroupInvitationResponse(@NotNull Long invitationId,
-                                      @NotBlank String invitationKey) {
+public record GroupInvitationResponse(@NotNull Long groupId,
+                                      @NotBlank String groupName,
+                                      @NotBlank String groupDescription,
+                                      String groupThumbnailUrl,
+                                      @NotNull Long invitationId,
+                                      @NotBlank String invitationKey,
+                                      @NotNull Long inviterId) {
 
     public static GroupInvitationResponse fromEntity(GroupInvitation groupInvitation) {
-        return new GroupInvitationResponse(groupInvitation.getId(), groupInvitation.getInvitationKey());
+        return new GroupInvitationResponse(
+                groupInvitation.getGroup().getId(),
+                groupInvitation.getGroup().getGroupDetail().name(),
+                groupInvitation.getGroup().getGroupDetail().description(),
+                groupInvitation.getGroup().getGroupDetail().thumbnailUrl(),
+                groupInvitation.getId(),
+                groupInvitation.getInvitationKey(),
+                groupInvitation.getLastModifier());
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupListResponse.java
@@ -14,7 +14,7 @@ public record GroupListResponse(@NotNull @Valid List<GroupListItem> groups) {
                                 @NotBlank String name,
                                 String thumbnailUrl,
                                 @NotNull Integer numOfMembers,
-                                @NotBlank String lastSystemMessage) {
+                                @NotBlank String lastChatMessage) {
 
         public static GroupListItem fromEntity(Group group, ChatMessage chatMessage) {
             return new GroupListItem(
@@ -30,11 +30,11 @@ public record GroupListResponse(@NotNull @Valid List<GroupListItem> groups) {
     public static GroupListResponse fromEntities(List<Group> groups, List<ChatMessage> chatMessages) {
 
         Function<Group, GroupListItem> aggregateToListItem = group -> {
-            ChatMessage latestChatMessage = chatMessages.stream()
+            ChatMessage lastChatMessage = chatMessages.stream()
                     .filter(message -> message.isBelongTo(group.getId()))
                     .findFirst()
                     .orElseThrow(IllegalStateException::new);
-            return GroupListItem.fromEntity(group, latestChatMessage);
+            return GroupListItem.fromEntity(group, lastChatMessage);
         };
 
         return new GroupListResponse(

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
@@ -7,12 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sleppynavigators.studyupbackend.application.user.UserService;
 import sleppynavigators.studyupbackend.presentation.authentication.filter.UserPrincipal;
 import sleppynavigators.studyupbackend.presentation.common.SuccessResponse;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
+import sleppynavigators.studyupbackend.presentation.user.dto.response.UserResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse;
 
 @Tag(name = "User", description = "유저 관련 API")
@@ -22,6 +24,13 @@ import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskLi
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/{userId}")
+    @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다.")
+    public ResponseEntity<SuccessResponse<UserResponse>> getUserInfo(@PathVariable Long userId) {
+        UserResponse response = userService.getUser(userId);
+        return ResponseEntity.ok(new SuccessResponse<>(response));
+    }
 
     @GetMapping("/me/groups")
     @Operation(summary = "유저의 그룹 목록 조회", description = "유저의 그룹 목록을 조회합니다.")

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/user/dto/response/UserResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/user/dto/response/UserResponse.java
@@ -1,0 +1,17 @@
+package sleppynavigators.studyupbackend.presentation.user.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import org.jetbrains.annotations.NotNull;
+import sleppynavigators.studyupbackend.domain.user.User;
+
+public record UserResponse(@NotNull Long id,
+                           @NotBlank String name,
+                           @NotBlank String email) {
+
+    public static UserResponse fromEntity(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getUserProfile().username(),
+                user.getUserProfile().email());
+    }
+}

--- a/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
@@ -20,6 +20,7 @@ import sleppynavigators.studyupbackend.common.support.UserSupport;
 import sleppynavigators.studyupbackend.domain.bot.Bot;
 import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.event.ChallengeCancelEvent;
 import sleppynavigators.studyupbackend.domain.event.ChallengeCompleteEvent;
 import sleppynavigators.studyupbackend.domain.event.ChallengeCreateEvent;
 import sleppynavigators.studyupbackend.domain.group.Group;
@@ -98,5 +99,30 @@ class ChallengeServiceTest extends ApplicationBaseTest {
         // then
         verify(systemEventListener).handleSystemEvent(new ChallengeCompleteEvent(
                 testUser.getUserProfile().username(), challenge.getDetail().title(), testGroup.getId()));
+    }
+
+    @Test
+    @DisplayName("챌린지 취소 시 ChallengeCancelEvent가 발행된다")
+    void cancelChallenge_PublishesChallengeCancelEvent() {
+        // given
+        Challenge challenge = challengeSupport
+                .callToMakeChallengesWithTasks(testGroup, 3, 2, testUser);
+
+        // when
+        challengeService.cancelChallenge(testUser.getId(), challenge.getId());
+
+        // then
+        verify(systemEventListener).handleSystemEvent(
+                new ChallengeCreateEvent(
+                        testUser.getUserProfile().username(),
+                        challenge.getDetail().title(),
+                        testGroup.getId())
+        );
+        verify(systemEventListener).handleSystemEvent(
+                new ChallengeCancelEvent(
+                        testUser.getUserProfile().username(),
+                        challenge.getDetail().title(),
+                        testGroup.getId())
+        );
     }
 }

--- a/src/test/java/sleppynavigators/studyupbackend/common/support/ChallengeSupport.java
+++ b/src/test/java/sleppynavigators/studyupbackend/common/support/ChallengeSupport.java
@@ -59,4 +59,8 @@ public class ChallengeSupport {
 
         return challengeRepository.findById(challengeResponse.id()).orElseThrow();
     }
+
+    public void callToCancelChallenge(User user, Challenge challenge) {
+        challengeService.cancelChallenge(user.getId(), challenge.getId());
+    }
 }

--- a/src/test/java/sleppynavigators/studyupbackend/domain/event/SystemEventTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/domain/event/SystemEventTest.java
@@ -14,10 +14,10 @@ class SystemEventTest {
     void userJoinEvent_GeneratesCorrectMessage() {
         // given
         UserJoinEvent event = new UserJoinEvent("testUser", 1L);
-        
+
         // when
         String message = event.generateMessage(SystemMessageTemplate.USER_JOIN_MESSAGE_TEMPLATE);
-        
+
         // then
         assertThat(message).isEqualTo("testUser님이 그룹에 참여했습니다.");
     }
@@ -27,10 +27,10 @@ class SystemEventTest {
     void userLeaveEvent_GeneratesCorrectMessage() {
         // given
         UserLeaveEvent event = new UserLeaveEvent("testUser", 1L);
-        
+
         // when
         String message = event.generateMessage(SystemMessageTemplate.USER_LEAVE_MESSAGE_TEMPLATE);
-        
+
         // then
         assertThat(message).isEqualTo("testUser님이 그룹을 나갔습니다.");
     }
@@ -40,10 +40,10 @@ class SystemEventTest {
     void challengeCreateEvent_GeneratesCorrectMessage() {
         // given
         ChallengeCreateEvent event = new ChallengeCreateEvent("testUser", "스터디하기", 1L);
-        
+
         // when
         String message = event.generateMessage(SystemMessageTemplate.CHALLENGE_CREATE_MESSAGE_TEMPLATE);
-        
+
         // then
         assertThat(message).isEqualTo("testUser님이 '스터디하기' 챌린지를 생성했습니다.");
     }
@@ -53,12 +53,25 @@ class SystemEventTest {
     void challengeCompleteEvent_GeneratesCorrectMessage() {
         // given
         ChallengeCompleteEvent event = new ChallengeCompleteEvent("testUser", "스터디하기", 1L);
-        
+
         // when
         String message = event.generateMessage(SystemMessageTemplate.CHALLENGE_COMPLETE_MESSAGE_TEMPLATE);
-        
+
         // then
         assertThat(message).isEqualTo("testUser님이 '스터디하기' 챌린지를 완료했습니다.");
+    }
+
+    @Test
+    @DisplayName("ChallengeCancelEvent의 메시지가 올바르게 생성된다")
+    void challengeCancelEvent_GeneratesCorrectMessage() {
+        // given
+        ChallengeCancelEvent event = new ChallengeCancelEvent("testUser", "스터디하기", 1L);
+
+        // when
+        String message = event.generateMessage(SystemMessageTemplate.CHALLENGE_CANCEL_MESSAGE_TEMPLATE);
+
+        // then
+        assertThat(message).isEqualTo("testUser님이 '스터디하기' 챌린지를 취소했습니다.");
     }
 
     @Test
@@ -67,10 +80,10 @@ class SystemEventTest {
         // given
         Long groupId = 1L;
         UserJoinEvent event = new UserJoinEvent("testUser", groupId);
-        
+
         // when
         Long result = event.getGroupId();
-        
+
         // then
         assertThat(result).isEqualTo(groupId);
     }
@@ -80,10 +93,10 @@ class SystemEventTest {
     void event_ReturnsCorrectType() {
         // given
         UserJoinEvent event = new UserJoinEvent("testUser", 1L);
-        
+
         // when
         SystemEventType type = event.getType();
-        
+
         // then
         assertThat(type).isEqualTo(SystemEventType.USER_JOIN);
     }

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/group/GroupControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/group/GroupControllerTest.java
@@ -242,8 +242,11 @@ public class GroupControllerTest extends RestAssuredBaseTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
-        assertThat(response.jsonPath().getObject("data", GroupResponse.class))
-                .satisfies(data -> assertThat(this.validator.validate(data)).isEmpty());
+        assertThat(response.jsonPath().getObject("data", GroupInvitationResponse.class))
+                .satisfies(data -> {
+                    assertThat(this.validator.validate(data)).isEmpty();
+                    assertThat(data.groupId()).isEqualTo(groupToInvite.getId());
+                });
     }
 
     @Test

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
@@ -23,6 +23,7 @@ import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 import sleppynavigators.studyupbackend.domain.group.Group;
 import sleppynavigators.studyupbackend.domain.user.User;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
+import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse.GroupListItem;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse.UserTaskGroupDetail;
@@ -87,6 +88,13 @@ public class UserControllerTest extends RestAssuredBaseTest {
         Group group2 = groupSupport.callToMakeGroup(List.of(currentUser, anotherUser1));
         Group group3 = groupSupport.callToMakeGroup(List.of(currentUser, anotherUser2, anotherUser3));
 
+        Challenge challenge1 = challengeSupport
+                .callToMakeChallengesWithTasks(group1, 3, 2, currentUser);
+        Challenge challenge2 = challengeSupport
+                .callToMakeChallengesWithTasks(group2, 4, 0, currentUser);
+
+        challengeSupport.callToCancelChallenge(currentUser, challenge1);
+
         // when
         ExtractableResponse<?> response = with()
                 .when().request(GET, "/users/me/groups")
@@ -99,8 +107,13 @@ public class UserControllerTest extends RestAssuredBaseTest {
                 .satisfies(data -> {
                     assertThat(this.validator.validate(data)).isEmpty();
                     assertThat(data.groups()).hasSize(3);
-                    assertThat(data.groups()).map(GroupListResponse.GroupListItem::numOfMembers)
+                    assertThat(data.groups()).map(GroupListItem::numOfMembers)
                             .containsExactly(1, 2, 3);
+                    assertThat(data.groups()).map(GroupListItem::lastChatMessage)
+                            .containsExactly(
+                                    "test-user님이 'test-challenge' 챌린지를 취소했습니다.",
+                                    "test-user님이 'test-challenge' 챌린지를 생성했습니다.",
+                                    "test-user님이 그룹에 참여했습니다.");
                 });
     }
 

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
@@ -23,6 +23,7 @@ import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 import sleppynavigators.studyupbackend.domain.group.Group;
 import sleppynavigators.studyupbackend.domain.user.User;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
+import sleppynavigators.studyupbackend.presentation.user.dto.response.UserResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse.UserTaskGroupDetail;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse.UserTaskListItem;
@@ -51,6 +52,27 @@ public class UserControllerTest extends RestAssuredBaseTest {
         RestAssured.requestSpecification = new RequestSpecBuilder()
                 .addHeader("Authorization", bearerToken)
                 .build();
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회에 성공한다")
+    void getUserInfo_Success() {
+        // given
+        User userToQuery = userSupport.registerUserToDB();
+
+        // when
+        ExtractableResponse<?> response = with()
+                .when().request(GET, "/users/{userId}", userToQuery.getId())
+                .then()
+                .log().all().extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.jsonPath().getObject("data", UserResponse.class))
+                .satisfies(data -> {
+                    assertThat(this.validator.validate(data)).isEmpty();
+                    assertThat(data.id()).isEqualTo(userToQuery.getId());
+                });
     }
 
     @Test


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 엔티티 시간과 수정자를 추적하기 시작합니다.
- 변경사항 : 그룹 초대를 생성한 사람이 누구인지 알려줍니다. 이를 위해서 유저 정보 조회 API도 추가합니다. 24시간 이내 챌린지 취소도 가능합니다.
- 목표가 아닌 것 : 그룹 목록 조회 시에 마지막 시스템 메시지 포함

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

- 다음 작업으로, 그룹 목록 조회 시에 해당 그룹의 마지막 시스템 메시지를 클라이언트에 전송해야 합니다.
- 양식은 대략 `누군가님이 무언가를 했다고 하네요~ 3h`와 같은 느낌으로 생각하고 있었습니다.
- 대략적인 시스템 메시지 구현이 완료되었다고 알고 있는데, 해당 정보를 어떻게 조합하면 좋을까요? @pjy1368 
- 더해서, 챌린지 생성 시에 이벤트가 발행되고 있습니다. 챌린지 취소 시에도 이벤트 발행이 필요할까요? @pjy1368 

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

없음

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다
