### PR TITLE
Feat :  rename response field to `memberCount`

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupListResponse.java
@@ -14,7 +14,7 @@ public record GroupListResponse(@NotNull @Valid List<GroupListItem> groups) {
     public record GroupListItem(@NotNull Long id,
                                 @NotBlank String name,
                                 String thumbnailUrl,
-                                @NotNull Integer numOfMembers,
+                                @NotNull Integer memberCount,
                                 @NotBlank String lastChatMessage) {
 
         public static GroupListItem fromEntity(GroupWithLastChatMessage groupWithLastChatMessage) {

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/user/UserControllerTest.java
@@ -111,7 +111,7 @@ public class UserControllerTest extends RestAssuredBaseTest {
                 .satisfies(data -> {
                     assertThat(this.validator.validate(data)).isEmpty();
                     assertThat(data.groups()).hasSize(3);
-                    assertThat(data.groups()).map(GroupListItem::numOfMembers)
+                    assertThat(data.groups()).map(GroupListItem::memberCount)
                             .containsExactly(1, 2, 3);
                     assertThat(data.groups()).map(GroupListItem::lastChatMessage)
                             .containsExactly(
@@ -151,7 +151,7 @@ public class UserControllerTest extends RestAssuredBaseTest {
                 .satisfies(data -> {
                     assertThat(this.validator.validate(data)).isEmpty();
                     assertThat(data.groups()).hasSize(3);
-                    assertThat(data.groups()).map(GroupListItem::numOfMembers)
+                    assertThat(data.groups()).map(GroupListItem::memberCount)
                             .containsExactly(2, 1, 3);
                     assertThat(data.groups()).map(GroupListItem::lastChatMessage)
                             .containsExactly(


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 과거 수를 나타내는 변수의 이름을 `xxxCount`로 설정하기로 합의했었습니다. (#46)
- 변경사항 : `numberOfMembers` 응답 필드를 `memberCount`로 이름 변경합니다
- 목표가 아닌 것 : 기능 변경

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

없음

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

없음

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 그룹 목록 응답에서 필드명이 'numOfMembers'에서 'memberCount'로 변경되었습니다.

- **Tests**
  - 관련 테스트 코드에서 필드명 변경에 맞춰 검증 항목이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->