### PR TITLE
Feat : hunting base

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
@@ -142,7 +142,7 @@ public class ChallengeService {
                     "User cannot hunt this challenge - userId: " + userId + ", challengeId: " + challengeId);
         }
 
-        Hunting hunting = huntingRepository.save(challenge.huntTask(taskId, user));
+        Hunting hunting = huntingRepository.save(challenge.rewardToHunter(taskId, user));
         return HuntingResponse.fromEntity(hunting);
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sleppynavigators.studyupbackend.application.event.SystemMessageEventPublisher;
 import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.challenge.hunting.Hunting;
 import sleppynavigators.studyupbackend.domain.event.ChallengeCancelEvent;
 import sleppynavigators.studyupbackend.domain.event.ChallengeCreateEvent;
 import sleppynavigators.studyupbackend.domain.event.TaskCertifyEvent;
@@ -20,12 +21,14 @@ import sleppynavigators.studyupbackend.exception.database.EntityNotFoundExceptio
 import sleppynavigators.studyupbackend.infrastructure.challenge.ChallengeRepository;
 import sleppynavigators.studyupbackend.infrastructure.challenge.TaskQueryOptions;
 import sleppynavigators.studyupbackend.infrastructure.challenge.TaskRepository;
+import sleppynavigators.studyupbackend.infrastructure.challenge.hunting.HuntingRepository;
 import sleppynavigators.studyupbackend.infrastructure.group.GroupRepository;
 import sleppynavigators.studyupbackend.infrastructure.user.UserRepository;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.request.ChallengeCreationRequest;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.request.TaskCertificationRequest;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.request.TaskSearch;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.response.ChallengeResponse;
+import sleppynavigators.studyupbackend.presentation.challenge.dto.response.HuntingResponse;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskListResponse;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskResponse;
 
@@ -38,6 +41,7 @@ public class ChallengeService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final TaskRepository taskRepository;
+    private final HuntingRepository huntingRepository;
     private final SystemMessageEventPublisher systemMessageEventPublisher;
 
     @Transactional
@@ -124,6 +128,22 @@ public class ChallengeService {
         } catch (IllegalArgumentException ex) {
             throw new InvalidPayloadException(ex);
         }
+    }
+
+    @Transactional
+    public HuntingResponse huntTask(Long userId, Long challengeId, Long taskId) {
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found - userId: " + userId));
+        Challenge challenge = challengeRepository.findByIdForUpdate(challengeId)
+                .orElseThrow(() -> new EntityNotFoundException("Challenge not found - challengeId: " + challengeId));
+
+        if (!challenge.canHunt(user)) {
+            throw new ForbiddenContentException(
+                    "User cannot hunt this challenge - userId: " + userId + ", challengeId: " + challengeId);
+        }
+
+        Hunting hunting = huntingRepository.save(challenge.huntTask(taskId, user));
+        return HuntingResponse.fromEntity(hunting);
     }
 
     @Transactional

--- a/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
@@ -52,7 +52,7 @@ public class ChallengeService {
                     "User cannot create challenge in this group - userId: " + userId + ", groupId: " + groupId);
         }
 
-        user.deductEquity(request.deposit());
+        user.deductPoint(request.deposit());
         Challenge challenge = challengeRepository.save(request.toEntity(user, group));
 
         ChallengeCreateEvent event = new ChallengeCreateEvent(

--- a/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/challenge/ChallengeService.java
@@ -142,8 +142,13 @@ public class ChallengeService {
                     "User cannot hunt this challenge - userId: " + userId + ", challengeId: " + challengeId);
         }
 
-        Hunting hunting = huntingRepository.save(challenge.rewardToHunter(taskId, user));
-        return HuntingResponse.fromEntity(hunting);
+        // Caution!
+        // This includes calculating the cap on the number of hunters per task,
+        // which requires you to watch out for Phantom Leads.
+        // (We use InnoDB's Repeatable Read isolation level)
+        Hunting hunting = challenge.rewardToHunter(taskId, user);
+        Hunting saved = huntingRepository.save(hunting);
+        return HuntingResponse.fromEntity(saved);
     }
 
     @Transactional

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -86,7 +86,7 @@ public class Challenge extends TimeAuditBaseEntity {
         }
 
         Point reward = deposit.multiply(1 + REWARD_RATE);
-        owner.grantEquity(reward.getAmount());
+        owner.grantPoint(reward.getAmount());
     }
 
     public Task getRecentCertifiedTask() {

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -93,6 +93,10 @@ public class Challenge extends TimeAuditBaseEntity {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Task not found - taskId: " + taskId));
 
+        if (!targetTask.isFailed()) {
+            throw new ForbiddenContentException("Task is not failed - taskId: " + taskId);
+        }
+
         long hunterLimitPerTask = Math.round(group.getNumOfMembers() * HUNTER_LIMIT_PER_TASK_RATIO);
         if (targetTask.getHuntingCount() >= hunterLimitPerTask) { // Be careful with PhantomRead
             throw new ForbiddenContentException("Hunting limit reached for this task - taskId: " + taskId);

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -16,12 +16,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.SoftDelete;
+import sleppynavigators.studyupbackend.domain.challenge.hunting.Hunting;
+import sleppynavigators.studyupbackend.domain.challenge.hunting.vo.Deposit;
 import sleppynavigators.studyupbackend.domain.challenge.vo.ChallengeDetail;
 import sleppynavigators.studyupbackend.domain.common.TimeAuditBaseEntity;
 import sleppynavigators.studyupbackend.domain.group.Group;
 import sleppynavigators.studyupbackend.domain.point.vo.Point;
 import sleppynavigators.studyupbackend.domain.user.User;
 import sleppynavigators.studyupbackend.exception.business.ChallengeInProgressException;
+import sleppynavigators.studyupbackend.exception.business.ForbiddenContentException;
 
 @SoftDelete
 @Entity(name = "challenges")
@@ -29,8 +32,8 @@ import sleppynavigators.studyupbackend.exception.business.ChallengeInProgressExc
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Challenge extends TimeAuditBaseEntity {
 
-    private static final double REWARD_RATE = 0.1;
     private static final long MODIFIABLE_PERIOD_HOUR = 24L;
+    private static final double HUNTER_LIMIT_PER_TASK_RATIO = 0.3;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "owner_id", nullable = false, updatable = false)
@@ -45,7 +48,7 @@ public class Challenge extends TimeAuditBaseEntity {
     private ChallengeDetail detail;
 
     @Embedded
-    private Point deposit;
+    private Deposit deposit;
 
     @OneToMany(mappedBy = "challenge", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Task> tasks;
@@ -55,7 +58,7 @@ public class Challenge extends TimeAuditBaseEntity {
         this.owner = owner;
         this.group = group;
         this.detail = new ChallengeDetail(title, description);
-        this.deposit = new Point(deposit);
+        this.deposit = new Deposit(deposit);
         this.tasks = new ArrayList<>();
     }
 
@@ -85,7 +88,7 @@ public class Challenge extends TimeAuditBaseEntity {
             throw new ChallengeInProgressException();
         }
 
-        Point reward = deposit.multiply(1 + REWARD_RATE);
+        Point reward = deposit.calculateReward();
         owner.grantPoint(reward.getAmount());
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -87,7 +87,7 @@ public class Challenge extends TimeAuditBaseEntity {
         return group.hasMember(user);
     }
 
-    public Hunting huntTask(Long taskId, User hunter) {
+    public Hunting rewardToHunter(Long taskId, User hunter) {
         Task targetTask = tasks.stream()
                 .filter(task -> task.getId().equals(taskId))
                 .findFirst()

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -98,7 +98,7 @@ public class Challenge extends TimeAuditBaseEntity {
         }
 
         long hunterLimitPerTask = Math.round(group.getNumOfMembers() * HUNTER_LIMIT_PER_TASK_RATIO);
-        if (targetTask.getHuntingCount() >= hunterLimitPerTask) { // Be careful with PhantomRead
+        if (targetTask.getHuntingCount() >= hunterLimitPerTask) {
             throw new ForbiddenContentException("Hunting limit reached for this task - taskId: " + taskId);
         }
 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/hunting/Hunting.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/hunting/Hunting.java
@@ -1,0 +1,42 @@
+package sleppynavigators.studyupbackend.domain.challenge.hunting;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.common.TimeAuditBaseEntity;
+import sleppynavigators.studyupbackend.domain.point.vo.Point;
+import sleppynavigators.studyupbackend.domain.user.User;
+
+@SoftDelete
+@Entity(name = "huntings")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Hunting extends TimeAuditBaseEntity {
+
+    @Embedded
+    private Point reward;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "task_id", nullable = false, updatable = false)
+    private Task target;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "hunter_id", nullable = false, updatable = false)
+    private User hunter;
+
+    public Hunting(Long reward, Task target, User hunter) {
+        this.reward = new Point(reward);
+        this.target = target;
+        this.hunter = hunter;
+    }
+
+    public boolean isHunter(User user) {
+        return this.hunter.equals(user);
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/hunting/vo/Deposit.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/hunting/vo/Deposit.java
@@ -1,0 +1,38 @@
+package sleppynavigators.studyupbackend.domain.challenge.hunting.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import sleppynavigators.studyupbackend.domain.point.vo.Point;
+
+@Embeddable
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter(AccessLevel.PROTECTED)
+public class Deposit {
+
+    private static final double REWARD_RATE = 0.1;
+
+    @Column(nullable = false, updatable = false)
+    private Long initialAmount;
+
+    @Embedded
+    private Point remain;
+
+    public Deposit(Long initialAmount) {
+        this.initialAmount = initialAmount;
+        this.remain = new Point(initialAmount);
+    }
+
+    public Point calculateReward() {
+        return remain.multiply(1 + REWARD_RATE);
+    }
+
+    public void subtract(Long amount) {
+        remain = remain.subtract(amount);
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/domain/user/User.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/user/User.java
@@ -29,11 +29,11 @@ public class User extends TimeAuditBaseEntity {
         this.point = new Point(INITIAL_POINT);
     }
 
-    public void grantEquity(Long amount) {
+    public void grantPoint(Long amount) {
         point = point.add(amount);
     }
 
-    public void deductEquity(Long amount) {
+    public void deductPoint(Long amount) {
         if (point.getAmount() < amount) {
             throw new InSufficientPointsException(
                     "Insufficient equity to deduct - current equity: " + point.getAmount() + ", requested: " + amount);

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/ChallengeRepository.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/ChallengeRepository.java
@@ -1,7 +1,20 @@
 package sleppynavigators.studyupbackend.infrastructure.challenge;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import sleppynavigators.studyupbackend.domain.challenge.Challenge;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeQueryRepository {
+
+    /**
+     * <b>Caution</b> <code>Challenge</code>s queried through this method must be registered in the JPA persistence
+     * context, so <code>Challenge</code>s retrieved without a lock must <b>not</b> be registered in the JPA persistence
+     * context beforehand. Be especially careful with auto-enrollment via JPA direct association.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM challenges c WHERE c.id = :id")
+    Optional<Challenge> findByIdForUpdate(Long id);
 }

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/hunting/HuntingRepository.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/hunting/HuntingRepository.java
@@ -1,0 +1,7 @@
+package sleppynavigators.studyupbackend.infrastructure.challenge.hunting;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sleppynavigators.studyupbackend.domain.challenge.hunting.Hunting;
+
+public interface HuntingRepository extends JpaRepository<Hunting, Long> {
+}

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeController.java
@@ -18,6 +18,7 @@ import sleppynavigators.studyupbackend.application.challenge.ChallengeService;
 import sleppynavigators.studyupbackend.presentation.authentication.filter.UserPrincipal;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.request.TaskCertificationRequest;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.request.TaskSearch;
+import sleppynavigators.studyupbackend.presentation.challenge.dto.response.HuntingResponse;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskListResponse;
 import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskResponse;
 import sleppynavigators.studyupbackend.presentation.common.SuccessResponse;
@@ -64,6 +65,18 @@ public class ChallengeController {
     ) {
         Long userId = userPrincipal.userId();
         TaskResponse response = challengeService.completeTask(userId, challengeId, taskId, taskCertificationRequest);
+        return ResponseEntity.ok(new SuccessResponse<>(response));
+    }
+
+    @PostMapping("/{challengeId}/tasks/{taskId}/hunt")
+    @Operation(summary = "테스크 헌팅", description = "테스크를 헌팅합니다.")
+    public ResponseEntity<SuccessResponse<HuntingResponse>> huntTask(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long challengeId,
+            @PathVariable Long taskId
+    ) {
+        Long userId = userPrincipal.userId();
+        HuntingResponse response = challengeService.huntTask(userId, challengeId, taskId);
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/ChallengeResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/ChallengeResponse.java
@@ -30,6 +30,6 @@ public record ChallengeResponse(
                 challenge.getDetail().getTitle(),
                 challenge.getDeadline().atZone(ZoneId.systemDefault()),
                 challenge.getDetail().getDescription(),
-                challenge.getDeposit().getAmount());
+                challenge.getDeposit().getRemain().getAmount());
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/HuntingResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/HuntingResponse.java
@@ -1,0 +1,14 @@
+package sleppynavigators.studyupbackend.presentation.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import sleppynavigators.studyupbackend.domain.challenge.hunting.Hunting;
+
+@Schema(description = "헌팅 결과 응답")
+public record HuntingResponse(@Schema(description = "헌팅 보상 포인트", example = "1000")
+                              @NotNull Long point) {
+
+    public static HuntingResponse fromEntity(Hunting hunting) {
+        return new HuntingResponse(hunting.getReward().getAmount());
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/TaskChallengeDTO.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/challenge/dto/response/TaskChallengeDTO.java
@@ -23,7 +23,7 @@ public record TaskChallengeDTO(
         return new TaskChallengeDTO(
                 task.getChallenge().getId(),
                 task.getChallenge().getDetail().getTitle(),
-                task.getChallenge().getDeposit().getAmount(),
+                task.getChallenge().getDeposit().getRemain().getAmount(),
                 task.getChallenge().isCompleted());
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupChallengeListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupChallengeListResponse.java
@@ -59,7 +59,7 @@ public record GroupChallengeListResponse(
                     challenge.getDetail().getTitle(),
                     challenge.getDeadline().atZone(ZoneId.systemDefault()),
                     challenge.getDetail().getDescription(),
-                    challenge.getDeposit().getAmount(),
+                    challenge.getDeposit().getRemain().getAmount(),
                     challenge.isCompleted(),
                     ChallengerDTO.fromEntity(challenge),
                     (recentCertifiedTask != null) ?

--- a/src/main/resources/db/migration/V0.0.2__huntings.sql
+++ b/src/main/resources/db/migration/V0.0.2__huntings.sql
@@ -1,0 +1,27 @@
+-- 1.1. Add initial_amount column to challenges table (allow NULL initially)
+ALTER TABLE challenges
+    ADD COLUMN initial_amount bigint null;
+
+-- 1.2. Update existing challenges to have default values
+UPDATE challenges
+SET initial_amount = amount;
+
+-- 1.3. Add NOT NULL constraints to challenges columns
+ALTER TABLE challenges
+    MODIFY COLUMN initial_amount bigint not null;
+
+-- 2. Create huntings table
+CREATE TABLE huntings
+(
+    id         bigint auto_increment primary key,
+    amount     bigint      not null,
+    hunter_id  bigint      not null,
+    task_id    bigint      not null,
+    deleted    bit         not null comment 'Soft-delete indicator',
+    created_at datetime(6) not null,
+    updated_at datetime(6) not null,
+    constraint FKmfgv5v293958k0kkog8hj24qr
+        foreign key (hunter_id) references users (id),
+    constraint FKnqgdpqd6yclj3ul8sourki49i
+        foreign key (task_id) references tasks (id)
+);

--- a/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
@@ -143,7 +143,7 @@ class ChallengeServiceTest extends ApplicationBaseTest {
                 .callToMakeCompletedChallengeWithTasks(testGroup, 3, testUser);
         User challenger = challenge.getOwner();
         Long initialChallengerEquity = challenger.getPoint().getAmount();
-        Long remainingDeposit = challenge.getDeposit().getAmount();
+        Long remainingDeposit = challenge.getDeposit().getRemain().getAmount();
 
         // when
         challengeService.settlementReward(challenger.getId(), challenge.getId());

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/group/GroupControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/group/GroupControllerTest.java
@@ -452,32 +452,6 @@ public class GroupControllerTest extends RestAssuredBaseTest {
     }
 
     @Test
-    @DisplayName("그룹에 챌린지를 등록할 때 마감일이 현재 시각보다 이전이면 오류로 응답한다")
-    void addChallengeToGroup_PastDeadline() {
-        // given
-        Group groupToQuery = groupSupport.callToMakeGroup(List.of(currentUser));
-
-        ChallengeCreationRequest request = new ChallengeCreationRequest(
-                "test challenge", "test description",
-                List.of(new TaskRequest("test task 1", ZonedDateTime.now().minusHours(3)),
-                        new TaskRequest("test task 2", ZonedDateTime.now().minusHours(6)),
-                        new TaskRequest("test task 3", ZonedDateTime.now().minusHours(9))),
-                10L);
-
-        // when
-        ExtractableResponse<?> response = with()
-                .body(request)
-                .when().request(POST, "/groups/{groupId}/challenges", groupToQuery.getId())
-                .then()
-                .log().all().extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-        assertThat(response.jsonPath().getString("code")).isEqualTo(ErrorCode.INVALID_PAYLOAD.getCode());
-        assertThat(response.jsonPath().getString("message")).isEqualTo(ErrorCode.INVALID_PAYLOAD.getDefaultMessage());
-    }
-
-    @Test
     @DisplayName("그룹에 챌린지를 등록할 때 마감일이 현재 시각보다 이전인 테스크가 있으면 오류로 응답한다")
     void addChallengeToGroup_PastTaskDeadline() {
         // given


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 테스크 실패 시 패널티 부여, 감시자에게 감시 동기 부여
- 변경사항 : 실패한 테스크에 대한 보증금 헌팅 기능 구현
- 목표가 아닌 것 : 테스크 인증에 대한 이의 제기 기능 구현

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

- 헌팅 금액은 "챌린지 전체 보증금"을 "테스크 총 개수"로 나눈 후, **30%의 멤버가 균등하게 수령할 수 있는 양**으로 설정했습니다.
- 동시성 제어를 위해 Lock 순서(`User` -> `Challenge`)를 유의해주세요.
- 테스크 당, 참여 가능한 헌터의 수를 제한하기 위해 헌팅의 수를 계산합니다. InnoDB의 Repeatable Read를 사용 중이므로, **팬텀 리드**를 주의해야 합니다. 현재 상황에서는 `Challenge`에 Lock을 걸고 있기 때문에 문제가 발생하지 않지만, 추후 코드베이스가 어떻게 변화할지는 불확실합니다. 따라서 한 줄 경고 코멘트를 남겨 두었습니다.

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

없음

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 챌린지의 실패한 태스크를 다른 사용자가 "헌팅"하여 보상을 받을 수 있는 헌팅 기능이 추가되었습니다.
  - 챌린지 태스크 헌팅을 위한 새로운 API 엔드포인트가 제공됩니다.

- **버그 수정**
  - 챌린지, 태스크, 그룹 관련 응답에서 예치금이 남은 금액 기준으로 표시되도록 변경되었습니다.

- **테스트**
  - 헌팅 기능의 성공 및 실패 케이스를 검증하는 테스트가 추가되었습니다.
  - 포인트 부족 시 챌린지 추가 실패 테스트가 반영되었습니다.

- **기타**
  - 포인트 관련 용어가 equity에서 point로 일괄 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->