### PR TITLE
Feat : ranking base

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/application/group/GroupMemberSortType.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/group/GroupMemberSortType.java
@@ -1,0 +1,8 @@
+package sleppynavigators.studyupbackend.application.group;
+
+public enum GroupMemberSortType {
+    POINT,
+    AVERAGE_CHALLENGE_COMPLETION_RATE,
+    HUNTING_COUNT,
+    NONE,
+}

--- a/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
@@ -188,24 +188,24 @@ public class GroupService {
         }
 
         List<GroupMember> members = groupMemberRepository.findAllByGroupId(group.getId());
-        GroupMemberListResponse response = GroupMemberListResponse.fromEntities(members);
-        sortGroupMemberListResponse(response, groupMemberSearch.sortBy());
-        return response;
+        List<GroupMember> sortedMembers = sortGroupMemberListResponse(members, groupMemberSearch.sortBy());
+        return GroupMemberListResponse.fromEntities(sortedMembers);
     }
 
-    private void sortGroupMemberListResponse(GroupMemberListResponse response, GroupMemberSortType sortType) {
-        switch (sortType) {
-            case POINT -> response.members()
-                    .sort((m1, m2) -> Long.compare(m2.points(), m1.points()));
-            case AVERAGE_CHALLENGE_COMPLETION_RATE -> response.members()
-                    .sort((m1, m2) ->
-                            Double.compare(m2.averageChallengeCompletionRate(), m1.averageChallengeCompletionRate()));
-            case HUNTING_COUNT -> response.members()
-                    .sort((m1, m2) -> Long.compare(m2.huntingCount(), m1.huntingCount()));
-            case NONE -> {
-                // No sorting
-            }
-            default -> throw new IllegalArgumentException("Invalid sort type: " + sortType);
-        }
+    private List<GroupMember> sortGroupMemberListResponse(List<GroupMember> members, GroupMemberSortType sortType) {
+        return switch (sortType) {
+            case POINT -> members.stream()
+                    .sorted((m1, m2) -> Long.compare(m2.getPoints(), m1.getPoints()))
+                    .toList();
+            case AVERAGE_CHALLENGE_COMPLETION_RATE -> members.stream()
+                    .sorted((m1, m2) ->
+                            Double.compare(m2.calcAvgChallengeCompletionRate(), m1.calcAvgChallengeCompletionRate()))
+                    .toList();
+            case HUNTING_COUNT -> members.stream()
+                    .sorted((m1, m2) ->
+                            Long.compare(m2.calcHuntingCount(), m1.calcHuntingCount()))
+                    .toList();
+            case NONE -> members; // No sorting, return as is
+        };
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
+++ b/src/main/java/sleppynavigators/studyupbackend/application/group/GroupService.java
@@ -192,6 +192,7 @@ public class GroupService {
         return GroupMemberListResponse.fromEntities(sortedMembers);
     }
 
+    // TODO: Consider de-normalizing the GroupMember entity and sorting directly in the database query.
     private List<GroupMember> sortGroupMemberListResponse(List<GroupMember> members, GroupMemberSortType sortType) {
         return switch (sortType) {
             case POINT -> members.stream()

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -128,7 +128,7 @@ public class Challenge extends TimeAuditBaseEntity {
         return detail.isOverdue();
     }
 
-    public double calcCompletionRate() {
+    public double calcSuccessRate() {
         if (tasks.isEmpty()) {
             return 0.0;
         }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Challenge.java
@@ -133,7 +133,7 @@ public class Challenge extends TimeAuditBaseEntity {
             return 0.0;
         }
 
-        long completedTasks = tasks.stream().filter(Task::isCompleted).count();
+        long completedTasks = tasks.stream().filter(Task::isSucceed).count();
         return (double) completedTasks / tasks.size() * 100;
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
@@ -38,6 +38,7 @@ public class GroupMember extends TimeAuditBaseEntity {
         return user.getPoint().getAmount();
     }
 
+    // TODO: De-normalize this if performance becomes an issue.
     public Double calcAvgChallengeCompletionRate() {
         return group.getChallenges().stream()
                 .filter(challenge -> challenge.isOwner(user))
@@ -47,6 +48,7 @@ public class GroupMember extends TimeAuditBaseEntity {
                 .orElse(0.0);
     }
 
+    // TODO: De-normalize this if performance becomes an issue.
     public Integer calcHuntingCount() {
         return group.getChallenges().stream()
                 .filter(challenge -> !challenge.isOwner(user))

--- a/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
@@ -43,19 +43,18 @@ public class GroupMember extends TimeAuditBaseEntity {
         return group.getChallenges().stream()
                 .filter(challenge -> challenge.isOwner(user))
                 .filter(Challenge::isCompleted)
-                .mapToDouble(Challenge::calcCompletionRate)
+                .mapToDouble(Challenge::calcSuccessRate)
                 .average()
                 .orElse(0.0);
     }
 
     // TODO: De-normalize this if performance becomes an issue.
-    public Integer calcHuntingCount() {
+    public Long calcHuntingCount() {
         return group.getChallenges().stream()
                 .filter(challenge -> !challenge.isOwner(user))
                 .flatMap(challenge -> challenge.getTasks().stream())
                 .filter(Task::isFailed)
                 .filter(task -> task.isHunter(user))
-                .toList()
-                .size();
+                .count();
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
@@ -7,6 +7,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
+import sleppynavigators.studyupbackend.domain.challenge.Challenge;
+import sleppynavigators.studyupbackend.domain.challenge.Task;
 import sleppynavigators.studyupbackend.domain.common.TimeAuditBaseEntity;
 import sleppynavigators.studyupbackend.domain.user.User;
 
@@ -30,5 +32,24 @@ public class GroupMember extends TimeAuditBaseEntity {
     public GroupMember(Group group, User user) {
         this.group = group;
         this.user = user;
+    }
+
+    public Double calcAvgChallengeCompletionRate() {
+        return group.getChallenges().stream()
+                .filter(challenge -> challenge.isOwner(user))
+                .filter(Challenge::isCompleted)
+                .mapToDouble(Challenge::calcCompletionRate)
+                .average()
+                .orElse(0.0);
+    }
+
+    public Integer calcHuntingCount() {
+        return group.getChallenges().stream()
+                .filter(challenge -> !challenge.isOwner(user))
+                .flatMap(challenge -> challenge.getTasks().stream())
+                .filter(Task::isFailed)
+                .filter(task -> task.isHunter(user))
+                .toList()
+                .size();
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
@@ -34,6 +34,10 @@ public class GroupMember extends TimeAuditBaseEntity {
         this.user = user;
     }
 
+    public Long getPoints() {
+        return user.getPoint().getAmount();
+    }
+
     public Double calcAvgChallengeCompletionRate() {
         return group.getChallenges().stream()
                 .filter(challenge -> challenge.isOwner(user))

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/ChallengeScheduler.java
@@ -45,7 +45,7 @@ public class ChallengeScheduler {
                     challenge.getGroup().getId(),
                     challenge.getId(),
                     challenge.getOwner().getId(),
-                    challenge.calcCompletionRate()
+                    challenge.calcSuccessRate()
             );
             challengeEventPublisher.publishChallengeCompleteEvent(event);
             notificationEventPublisher.publish(event);

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/group/GroupMemberRepository.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/group/GroupMemberRepository.java
@@ -1,5 +1,6 @@
 package sleppynavigators.studyupbackend.infrastructure.group;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sleppynavigators.studyupbackend.domain.group.GroupMember;
@@ -7,4 +8,6 @@ import sleppynavigators.studyupbackend.domain.group.GroupMember;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
     Optional<GroupMember> findByGroupIdAndUserId(Long groupId, Long userId);
+
+    List<GroupMember> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/common/argument/GroupMemberSearchArgumentResolver.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/common/argument/GroupMemberSearchArgumentResolver.java
@@ -1,0 +1,31 @@
+package sleppynavigators.studyupbackend.presentation.common.argument;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import sleppynavigators.studyupbackend.application.group.GroupMemberSortType;
+import sleppynavigators.studyupbackend.exception.network.InvalidApiException;
+import sleppynavigators.studyupbackend.presentation.group.dto.request.GroupMemberSearch;
+
+public class GroupMemberSearchArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return (parameter.hasParameterAnnotation(SearchParam.class) &&
+                parameter.nestedIfOptional().getParameterType().equals(GroupMemberSearch.class));
+    }
+
+    @Override
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        try {
+            String sortBy = webRequest.getParameter("sortBy");
+            return new GroupMemberSearch(sortBy != null ? GroupMemberSortType.valueOf(sortBy) : null);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidApiException("Invalid search option provided");
+        }
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/common/config/WebConfig.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/common/config/WebConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import sleppynavigators.studyupbackend.presentation.common.argument.ChallengeSearchArgumentResolver;
 import sleppynavigators.studyupbackend.presentation.common.argument.ChatMessageSearchArgumentResolver;
+import sleppynavigators.studyupbackend.presentation.common.argument.GroupMemberSearchArgumentResolver;
 import sleppynavigators.studyupbackend.presentation.common.argument.GroupSearchArgumentResolver;
 import sleppynavigators.studyupbackend.presentation.common.argument.TaskSearchArgumentResolver;
 
@@ -19,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
                         new ChatMessageSearchArgumentResolver(),
                         new TaskSearchArgumentResolver(),
                         new ChallengeSearchArgumentResolver(),
-                        new GroupSearchArgumentResolver()));
+                        new GroupSearchArgumentResolver(),
+                        new GroupMemberSearchArgumentResolver()));
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/GroupController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/GroupController.java
@@ -27,8 +27,10 @@ import sleppynavigators.studyupbackend.presentation.common.SuccessResponse;
 import sleppynavigators.studyupbackend.presentation.common.argument.SearchParam;
 import sleppynavigators.studyupbackend.presentation.group.dto.request.GroupCreationRequest;
 import sleppynavigators.studyupbackend.presentation.group.dto.request.GroupInvitationAcceptRequest;
+import sleppynavigators.studyupbackend.presentation.group.dto.request.GroupMemberSearch;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupChallengeListResponse;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupInvitationResponse;
+import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupMemberListResponse;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupResponse;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupTaskListResponse;
 
@@ -143,6 +145,18 @@ public class GroupController {
         Long userId = userPrincipal.userId();
         ChatMessageListResponse response = chatMessageService
                 .getMessages(userId, groupId, chatMessageSearch);
+        return ResponseEntity.ok(new SuccessResponse<>(response));
+    }
+
+    @GetMapping("/{groupId}/members")
+    @Operation(summary = "그룹 멤버 조회", description = "그룹의 멤버 목록을 조회합니다.")
+    public ResponseEntity<SuccessResponse<GroupMemberListResponse>> getGroupMembers(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long groupId,
+            @SearchParam @Valid GroupMemberSearch groupMemberSearch
+    ) {
+        Long userId = userPrincipal.userId();
+        GroupMemberListResponse response = groupService.getGroupMembers(userId, groupId, groupMemberSearch);
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/request/GroupMemberSearch.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/request/GroupMemberSearch.java
@@ -1,0 +1,21 @@
+package sleppynavigators.studyupbackend.presentation.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
+import sleppynavigators.studyupbackend.application.group.GroupMemberSortType;
+
+@ParameterObject
+@Schema(description = "그룹 멤버 검색 조건")
+public record GroupMemberSearch(
+        @Schema(description = "정렬 조건", example = "POINT")
+        GroupMemberSortType sortBy
+) {
+
+    private static final GroupMemberSortType DEFAULT_SORT_BY = GroupMemberSortType.NONE;
+
+    public GroupMemberSearch {
+        if (sortBy == null) {
+            sortBy = DEFAULT_SORT_BY;
+        }
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupMemberListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupMemberListResponse.java
@@ -1,0 +1,50 @@
+package sleppynavigators.studyupbackend.presentation.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import sleppynavigators.studyupbackend.domain.group.GroupMember;
+
+@Schema(description = "그룹 멤버 목록 응답")
+public record GroupMemberListResponse(
+        @Schema(description = "그룹 멤버 목록")
+        @NotNull List<GroupMemberListItem> members
+) {
+
+    public static GroupMemberListResponse fromEntities(List<GroupMember> groupMembers) {
+        return new GroupMemberListResponse(
+                groupMembers.stream()
+                        .map(GroupMemberListItem::fromEntity)
+                        .toList());
+    }
+
+    @Schema(description = "그룹 멤버")
+    public record GroupMemberListItem(
+            @Schema(description = "멤버 ID", example = "1")
+            @NotNull Long userId,
+
+            @Schema(description = "멤버 이름", example = "홍길동")
+            @NotBlank String userName,
+
+            @Schema(description = "멤버 보유 포인트", example = "1000")
+            @NotNull Long points,
+
+            @Schema(description = "멤버 평균 챌린지 완수율", example = "85.5")
+            @NotNull Double averageChallengeCompletionRate,
+
+            @Schema(description = "멤버 헌팅 횟수", example = "5")
+            @NotNull Long huntingCount
+    ) {
+
+        public static GroupMemberListItem fromEntity(GroupMember groupMember) {
+            return new GroupMemberListItem(
+                    groupMember.getUser().getId(),
+                    groupMember.getUser().getUserProfile().getUsername(),
+                    groupMember.getUser().getPoint().getAmount(),
+                    groupMember.calcAvgChallengeCompletionRate(),
+                    groupMember.calcHuntingCount().longValue()
+            );
+        }
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupMemberListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/group/dto/response/GroupMemberListResponse.java
@@ -43,7 +43,7 @@ public record GroupMemberListResponse(
                     groupMember.getUser().getUserProfile().getUsername(),
                     groupMember.getUser().getPoint().getAmount(),
                     groupMember.calcAvgChallengeCompletionRate(),
-                    groupMember.calcHuntingCount().longValue()
+                    groupMember.calcHuntingCount()
             );
         }
     }

--- a/src/test/java/sleppynavigators/studyupbackend/common/support/UserSupport.java
+++ b/src/test/java/sleppynavigators/studyupbackend/common/support/UserSupport.java
@@ -29,4 +29,11 @@ public class UserSupport {
         User user = new User(username, email);
         return userRepository.save(user);
     }
+
+    public User registerUserToDBWithPoints(Long points) {
+        User user = new User("test-user", "test-email");
+        user.deductPoint(user.getPoint().getAmount());
+        user.grantPoint(points);
+        return userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 그룹 멤버 조회 API 필요
- 변경사항 : 그룹 멤버 조회 API 구현
- 목표가 아닌 것 : 성능 향상

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

- 멤버 정렬 기준은 "포인트", "챌린지 완수율 평균치", "헌팅 횟수"로 설정했습니다.
- 멤버 조회에 페이지네이션은 적용하지 않았습니다. (불필요하다고 판단, 다른 서비스에서 멤버 조회에 페이지네이션 적용 사례 못찾음)
- "챌린지 완수율 평균치"와 "헌팅 횟수"를 늘 다시 계산하고 있는데, 추후 반정규화를 통한 성능 향상을 생각할 수 있습니다.
  - 당장 적용하기엔, 챌린지 완수 이벤트, 헌팅 이벤트 등 프로젝트의 이벤트 관계에서 변경이 필요하기 때문에 우선 미뤘습니다.
  - 별도 ISSUE를 생성, 관리하도록 하겠습니다.

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

1. 그룹 멤버 정보 유형의 타당성 재검토 필요. (현재는 "포인트", "헌팅 횟수", "평균 챌린지 완수율" 채택)
2. 그룹 멤버 정보의 반-정규화를 통한 성능 향상 검토. (이 경우 이벤트 시스템에 변경 전파 우려)

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 그룹 멤버 목록 조회 API가 추가되었습니다. 사용자는 그룹 내 멤버들을 포인트, 평균 챌린지 완료율, 헌팅 횟수 등 다양한 기준으로 정렬하여 조회할 수 있습니다.
- **버그 수정**
    - 챌린지 완료율 계산 기준이 완료된 작업에서 성공한 작업으로 변경되었습니다.
- **테스트**
    - 그룹 멤버 목록 조회 및 정렬 기능에 대한 다양한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->