### PR TITLE
Feat : group noti when task failure

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGenerator.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGenerator.java
@@ -1,0 +1,21 @@
+package sleppynavigators.studyupbackend.domain.chat.systemmessage;
+
+import org.springframework.stereotype.Component;
+import sleppynavigators.studyupbackend.domain.event.EventType;
+import sleppynavigators.studyupbackend.domain.event.TaskFailEvent;
+
+@Component
+public class TaskFailSystemMessageGenerator implements SystemMessageGenerator<TaskFailEvent> {
+
+    private static final String MESSAGE_FORMAT = "%s님이 '%s' 테스크에 실패했습니다. (%s)";
+
+    @Override
+    public String generate(TaskFailEvent event) {
+        return String.format(MESSAGE_FORMAT, event.userName(), event.taskName(), event.challengeName());
+    }
+
+    @Override
+    public EventType supportedEventType() {
+        return EventType.TASK_FAIL;
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/ChallengeCompleteEvent.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/ChallengeCompleteEvent.java
@@ -2,7 +2,7 @@ package sleppynavigators.studyupbackend.domain.event;
 
 public record ChallengeCompleteEvent(
         String userName, String challengeName, Long groupId, Long challengeId, Long challengerId, Double percentage)
-        implements SystemMessageEvent, GroupNotificationEvent {
+        implements SystemMessageEvent, PersonalNotificationEvent {
 
     @Override
     public EventType getType() {
@@ -12,5 +12,10 @@ public record ChallengeCompleteEvent(
     @Override
     public Long getGroupId() {
         return groupId;
+    }
+
+    @Override
+    public Long getUserId() {
+        return challengerId;
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/EventType.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/EventType.java
@@ -7,5 +7,6 @@ public enum EventType {
     CHALLENGE_COMPLETE,
     CHALLENGE_CANCEL,
     GROUP_CREATE,
-    TASK_CERTIFY
+    TASK_CERTIFY,
+    TASK_FAIL,
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskCertifyEvent.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskCertifyEvent.java
@@ -2,7 +2,7 @@ package sleppynavigators.studyupbackend.domain.event;
 
 public record TaskCertifyEvent(
         String userName, String challengeName, String taskName, Long groupId
-) implements SystemMessageEvent {
+) implements SystemMessageEvent, GroupNotificationEvent {
 
     @Override
     public EventType getType() {

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskFailEvent.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskFailEvent.java
@@ -1,0 +1,16 @@
+package sleppynavigators.studyupbackend.domain.event;
+
+public record TaskFailEvent(
+        String userName, String challengeName, Long groupId, Long challengeId, Long challengerId)
+        implements SystemMessageEvent, GroupNotificationEvent {
+
+    @Override
+    public EventType getType() {
+        return EventType.TASK_FAIL;
+    }
+
+    @Override
+    public Long getGroupId() {
+        return groupId;
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskFailEvent.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/event/TaskFailEvent.java
@@ -1,7 +1,7 @@
 package sleppynavigators.studyupbackend.domain.event;
 
 public record TaskFailEvent(
-        String userName, String challengeName, Long groupId, Long challengeId, Long challengerId)
+        String userName, String challengeName, String taskName, Long groupId)
         implements SystemMessageEvent, GroupNotificationEvent {
 
     @Override

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryOptions.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryOptions.java
@@ -36,4 +36,9 @@ public class TaskQueryOptions {
         QTask task = QTask.task;
         return task.challenge.owner.id.eq(ownerId);
     }
+
+    public static BooleanExpression getCompletedBetweenPredicate(LocalDateTime start, LocalDateTime end) {
+        QTask task = QTask.task;
+        return task.detail.deadline.between(start, end);
+    }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryRepository.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryRepository.java
@@ -6,5 +6,7 @@ import sleppynavigators.studyupbackend.domain.challenge.Task;
 
 public interface TaskQueryRepository {
 
+    List<Task> findAll(Predicate predicate);
+
     List<Task> findAll(Predicate predicate, Long pageNum, Integer pageSize);
 }

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryRepositoryImpl.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/TaskQueryRepositoryImpl.java
@@ -14,6 +14,15 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    public List<Task> findAll(Predicate predicate) {
+        QTask task = QTask.task;
+        return queryFactory
+                .selectFrom(task)
+                .where(predicate)
+                .fetch();
+    }
+
+    @Override
     public List<Task> findAll(Predicate predicate, Long pageNum, Integer pageSize) {
         QTask task = QTask.task;
         return queryFactory

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/ChallengeScheduler.java
@@ -39,6 +39,7 @@ public class ChallengeScheduler {
         List<Challenge> completedChallenges = challengeRepository.findAll(predicate);
 
         for (Challenge challenge : completedChallenges) {
+            log.info("ChallengeScheduler - Processing completed challenge: {}", challenge.getId());
             ChallengeCompleteEvent event = new ChallengeCompleteEvent(
                     challenge.getOwner().getUserProfile().getUsername(),
                     challenge.getDetail().getTitle(),

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
@@ -43,9 +43,8 @@ public class TaskScheduler {
             TaskFailEvent event = new TaskFailEvent(
                     task.getChallenge().getOwner().getUserProfile().getUsername(),
                     task.getChallenge().getDetail().getTitle(),
-                    task.getChallenge().getGroup().getId(),
-                    task.getChallenge().getId(),
-                    task.getChallenge().getOwner().getId()
+                    task.getDetail().getTitle(),
+                    task.getChallenge().getGroup().getId()
             );
             notificationEventPublisher.publish(event);
         }

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
@@ -1,0 +1,52 @@
+package sleppynavigators.studyupbackend.infrastructure.challenge.scheduler;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import sleppynavigators.studyupbackend.application.event.NotificationEventPublisher;
+import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.domain.event.TaskFailEvent;
+import sleppynavigators.studyupbackend.infrastructure.challenge.TaskQueryOptions;
+import sleppynavigators.studyupbackend.infrastructure.challenge.TaskRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class TaskScheduler {
+
+    private final NotificationEventPublisher notificationEventPublisher;
+    private final TaskRepository taskRepository;
+
+    @Value("${scheduler.challenge.check-expiration.interval-minutes}")
+    private long challengeCheckIntervalMinutes;
+
+    @Scheduled(cron = "${scheduler.challenge.check-expiration.cron}", zone = "Asia/Seoul")
+    @Transactional
+    public void checkFailedTasks() {
+        log.info("ChallengeScheduler - checkExpiredTasks() started");
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime baseTime = now.minusMinutes(challengeCheckIntervalMinutes);
+        BooleanExpression predicate = TaskQueryOptions.getCompletedBetweenPredicate(baseTime, now);
+        List<Task> expiredTasks = taskRepository.findAll(predicate);
+
+        for (Task task : expiredTasks) {
+            log.info("ChallengeScheduler - Processing expired task: {}", task.getId());
+            TaskFailEvent event = new TaskFailEvent(
+                    task.getChallenge().getOwner().getUserProfile().getUsername(),
+                    task.getChallenge().getDetail().getTitle(),
+                    task.getChallenge().getGroup().getId(),
+                    task.getChallenge().getId(),
+                    task.getChallenge().getOwner().getId()
+            );
+            notificationEventPublisher.publish(event);
+        }
+        log.info("ChallengeScheduler - checkExpiredTasks() completed");
+    }
+}

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import sleppynavigators.studyupbackend.application.challenge.TaskCertificationStatus;
 import sleppynavigators.studyupbackend.application.event.NotificationEventPublisher;
 import sleppynavigators.studyupbackend.domain.challenge.Task;
 import sleppynavigators.studyupbackend.domain.event.TaskFailEvent;
@@ -33,7 +34,8 @@ public class TaskScheduler {
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime baseTime = now.minusMinutes(challengeCheckIntervalMinutes);
-        BooleanExpression predicate = TaskQueryOptions.getCompletedBetweenPredicate(baseTime, now);
+        BooleanExpression predicate = TaskQueryOptions.getCompletedBetweenPredicate(baseTime, now)
+                .and(TaskQueryOptions.getStatusPredicate(TaskCertificationStatus.FAILED));
         List<Task> expiredTasks = taskRepository.findAll(predicate);
 
         for (Task task : expiredTasks) {

--- a/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
+++ b/src/main/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskScheduler.java
@@ -30,16 +30,16 @@ public class TaskScheduler {
     @Scheduled(cron = "${scheduler.challenge.check-expiration.cron}", zone = "Asia/Seoul")
     @Transactional
     public void checkFailedTasks() {
-        log.info("ChallengeScheduler - checkExpiredTasks() started");
+        log.info("TaskScheduler - checkFailedTasks() started");
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime baseTime = now.minusMinutes(challengeCheckIntervalMinutes);
         BooleanExpression predicate = TaskQueryOptions.getCompletedBetweenPredicate(baseTime, now)
                 .and(TaskQueryOptions.getStatusPredicate(TaskCertificationStatus.FAILED));
-        List<Task> expiredTasks = taskRepository.findAll(predicate);
+        List<Task> failedTasks = taskRepository.findAll(predicate);
 
-        for (Task task : expiredTasks) {
-            log.info("ChallengeScheduler - Processing expired task: {}", task.getId());
+        for (Task task : failedTasks) {
+            log.info("TaskScheduler - Processing failed task: {}", task.getId());
             TaskFailEvent event = new TaskFailEvent(
                     task.getChallenge().getOwner().getUserProfile().getUsername(),
                     task.getChallenge().getDetail().getTitle(),
@@ -49,6 +49,6 @@ public class TaskScheduler {
             );
             notificationEventPublisher.publish(event);
         }
-        log.info("ChallengeScheduler - checkExpiredTasks() completed");
+        log.info("TaskScheduler - checkFailedTasks() completed");
     }
 }

--- a/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/application/challenge/ChallengeServiceTest.java
@@ -1,6 +1,7 @@
 package sleppynavigators.studyupbackend.application.challenge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
 
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import sleppynavigators.studyupbackend.application.event.NotificationEventListener;
 import sleppynavigators.studyupbackend.application.event.SystemMessageEventListener;
 import sleppynavigators.studyupbackend.common.ApplicationBaseTest;
 import sleppynavigators.studyupbackend.common.support.BotSupport;
@@ -52,6 +54,9 @@ class ChallengeServiceTest extends ApplicationBaseTest {
     @MockitoSpyBean
     private SystemMessageEventListener systemEventListener;
 
+    @MockitoSpyBean
+    private NotificationEventListener notificationEventListener;
+
     private User testUser;
 
     private Group testGroup;
@@ -82,11 +87,7 @@ class ChallengeServiceTest extends ApplicationBaseTest {
         challengeService.createChallenge(testUser.getId(), testGroup.getId(), request);
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new ChallengeCreateEvent(testUser.getUserProfile().getUsername(),
-                        "testChallenge",
-                        testGroup.getId())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(ChallengeCreateEvent.class));
     }
 
     @Test
@@ -102,12 +103,7 @@ class ChallengeServiceTest extends ApplicationBaseTest {
         challengeService.cancelChallenge(testUser.getId(), challenge.getId());
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new ChallengeCancelEvent(
-                        testUser.getUserProfile().getUsername(),
-                        challenge.getDetail().getTitle(),
-                        testGroup.getId())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(ChallengeCancelEvent.class));
     }
 
     @Test
@@ -121,18 +117,14 @@ class ChallengeServiceTest extends ApplicationBaseTest {
                 );
 
         clearInvocations(systemEventListener);
+        clearInvocations(notificationEventListener);
 
         // when
         challengeService.completeTask(testUser.getId(), challenge.getId(), 1L, taskCertificationRequest);
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new TaskCertifyEvent(
-                        testUser.getUserProfile().getUsername(),
-                        challenge.getTasks().get(0).getDetail().getTitle(),
-                        challenge.getDetail().getTitle(),
-                        testGroup.getId())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(TaskCertifyEvent.class));
+        verify(notificationEventListener).handleNotificationEvent(any(TaskCertifyEvent.class));
     }
 
     @Test

--- a/src/test/java/sleppynavigators/studyupbackend/application/group/GroupServiceTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/application/group/GroupServiceTest.java
@@ -1,5 +1,6 @@
 package sleppynavigators.studyupbackend.application.group;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
 
@@ -70,9 +71,7 @@ class GroupServiceTest extends ApplicationBaseTest {
         GroupResponse response = groupService.createGroup(creator.getId(), request);
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new GroupCreateEvent(creator.getUserProfile().getUsername(), "스터디하기", response.id())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(GroupCreateEvent.class));
     }
 
     @Test
@@ -88,9 +87,7 @@ class GroupServiceTest extends ApplicationBaseTest {
         groupService.acceptInvitation(newUser.getId(), testGroup.getId(), testInvitation.getId(), request);
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new UserJoinEvent(testUser.getUserProfile().getUsername(), testGroup.getId())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(UserJoinEvent.class));
     }
 
     @Test
@@ -107,8 +104,6 @@ class GroupServiceTest extends ApplicationBaseTest {
         groupService.leaveGroup(anotherMember.getId(), groupToLeave.getId());
 
         // then
-        verify(systemEventListener).handleSystemMessageEvent(
-                new UserLeaveEvent(testUser.getUserProfile().getUsername(), groupToLeave.getId())
-        );
+        verify(systemEventListener).handleSystemMessageEvent(any(UserLeaveEvent.class));
     }
 }

--- a/src/test/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGeneratorTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGeneratorTest.java
@@ -11,7 +11,7 @@ public class TaskFailSystemMessageGeneratorTest {
     private final TaskFailSystemMessageGenerator generator = new TaskFailSystemMessageGenerator();
 
     @Test
-    void getEventType_ShouldReturnTaskCertify() {
+    void getEventType_ShouldReturnTaskFail() {
         // when
         EventType eventType = generator.supportedEventType();
 

--- a/src/test/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGeneratorTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/domain/chat/systemmessage/TaskFailSystemMessageGeneratorTest.java
@@ -1,0 +1,37 @@
+package sleppynavigators.studyupbackend.domain.chat.systemmessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import sleppynavigators.studyupbackend.domain.event.EventType;
+import sleppynavigators.studyupbackend.domain.event.TaskFailEvent;
+
+public class TaskFailSystemMessageGeneratorTest {
+
+    private final TaskFailSystemMessageGenerator generator = new TaskFailSystemMessageGenerator();
+
+    @Test
+    void getEventType_ShouldReturnTaskCertify() {
+        // when
+        EventType eventType = generator.supportedEventType();
+
+        // then
+        assertThat(eventType).isEqualTo(EventType.TASK_FAIL);
+    }
+
+    @Test
+    void generate_ShouldReturnFormattedMessage() {
+        // given
+        String userName = "홍길동";
+        String challengeName = "알고리즘 끝장내기";
+        String taskName = "알고리즘 문제 풀기";
+        Long groupId = 1L;
+        TaskFailEvent event = new TaskFailEvent(userName, challengeName, taskName, groupId);
+
+        // when
+        String message = generator.generate(event);
+
+        // then
+        assertThat(message).isEqualTo("홍길동님이 '알고리즘 문제 풀기' 테스크에 실패했습니다. (알고리즘 끝장내기)");
+    }
+}

--- a/src/test/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskSchedulerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/infrastructure/challenge/scheduler/TaskSchedulerTest.java
@@ -10,8 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import sleppynavigators.studyupbackend.application.event.NotificationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import sleppynavigators.studyupbackend.application.event.NotificationEventListener;
+import sleppynavigators.studyupbackend.application.event.SystemMessageEventListener;
 import sleppynavigators.studyupbackend.common.ApplicationBaseTest;
 import sleppynavigators.studyupbackend.common.support.ChallengeSupport;
 import sleppynavigators.studyupbackend.common.support.GroupSupport;
@@ -36,8 +37,11 @@ public class TaskSchedulerTest extends ApplicationBaseTest {
     @Autowired
     private ChallengeSupport challengeSupport;
 
-    @MockitoBean
-    private NotificationEventPublisher notificationEventPublisher;
+    @MockitoSpyBean
+    private SystemMessageEventListener systemEventListener;
+
+    @MockitoSpyBean
+    private NotificationEventListener notificationEventListener;
 
     private User currentUser;
 
@@ -57,13 +61,16 @@ public class TaskSchedulerTest extends ApplicationBaseTest {
         Challenge withCertifiedTasks = challengeSupport.callToMakeCompletedChallengeWithTasks(
                 groupToBelong, 10, currentUser);
 
-        clearInvocations(notificationEventPublisher);
+        clearInvocations(systemEventListener);
+        clearInvocations(notificationEventListener);
 
         // when
         taskScheduler.checkFailedTasks();
 
         // then
-        verify(notificationEventPublisher, times(5))
-                .publish(any(TaskFailEvent.class));
+        verify(systemEventListener, times(5))
+                .handleSystemMessageEvent(any(TaskFailEvent.class));
+        verify(notificationEventListener, times(5))
+                .handleNotificationEvent(any(TaskFailEvent.class));
     }
 }


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 테스크 실패 시, 알람 전송이 없었습니다.
- 변경사항 : 테스크 실패 시, 알람을 전송합니다. (챌린지 종료 알람 스코프를 그룹에서 개인으로 변경했습니다)
- 목표가 아닌 것 : 이 외 기능 변경

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

- 챌린지 종료 여부는 헌터들에겐 관심사가 아니라고 생각했습니다.
- 기획 상, 챌린지 완료 후 SNS에 자랑하는 상호작용은 챌린저에 한정되기 때문에, 알람 스코프를 개인으로 변경합니다.

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

없음

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 실패한 과제(Task Fail)에 대한 이벤트 및 알림 기능이 추가되었습니다.
	- 실패한 과제를 주기적으로 감지하고 알림을 발송하는 스케줄러가 도입되었습니다.
	- 과제 완료 시간 범위 필터링 기능이 추가되었습니다.
	- 실패한 과제에 대한 시스템 메시지 생성 기능이 추가되었습니다.

- **버그 수정**
	- 만료된 챌린지 완료 이벤트가 그룹 알림에서 사용자별 알림으로 전환되었습니다.
	- 과제 인증 이벤트에 그룹 알림 기능이 추가되었습니다.

- **테스트**
	- 실패한 과제 알림 및 챌린지 만료 알림 기능에 대한 테스트가 추가 및 보강되었습니다.
	- 이벤트 리스너 검증 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->