### PR TITLE
Feat : query huntable tasks

### DIFF
--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
@@ -96,11 +96,11 @@ public class Task extends TimeAuditBaseEntity {
                 .anyMatch(hunting -> hunting.isHunter(user));
     }
 
-    private boolean isHuntable() {
+    public boolean isHuntable() {
         return isFailed() && getHuntingCount() < calcHuntingCountLimit();
     }
 
-    private boolean canHunt(User hunter) {
+    public boolean canHunt(User hunter) {
         return challenge.canAccess(hunter) && !challenge.isOwner(hunter) && !isAlreadyHunt(hunter);
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
@@ -29,6 +29,8 @@ import sleppynavigators.studyupbackend.exception.business.OveredDeadlineExceptio
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Task extends TimeAuditBaseEntity {
 
+    private static final double HUNTER_LIMIT_PER_TASK_RATIO = 0.3;
+
     @Immutable
     @Embedded
     private TaskDetail detail;
@@ -63,22 +65,22 @@ public class Task extends TimeAuditBaseEntity {
         this.certification = new TaskCertification(externalLinks, imageUrls, LocalDateTime.now());
     }
 
-    public Integer getHuntingCount() {
-        return huntings.size();
+    public Long calcHuntingReward() {
+        return challenge.getDeposit().getInitialAmount() / challenge.getTasks().size() / calcHuntingCountLimit();
     }
 
-    public Hunting addHunting(Long amount, User hunter) {
-        if (isHunter(hunter)) {
-            throw new ForbiddenContentException("User has already hunted this task. - userId: " + hunter.getId());
+    public Hunting hunt(User hunter) {
+        if (!isHuntable()) {
+            throw new ForbiddenContentException("Task is not huntable - taskId: " + getId());
         }
 
-        Hunting hunting = new Hunting(amount, this, hunter);
+        if (!canHunt(hunter)) {
+            throw new ForbiddenContentException("User is not allowed to hunt this task - userId: " + hunter.getId());
+        }
+
+        Hunting hunting = new Hunting(calcHuntingReward(), this, hunter);
         huntings.add(hunting);
         return hunting;
-    }
-
-    public boolean isCompleted() {
-        return isSucceed() || isFailed();
     }
 
     public boolean isSucceed() {
@@ -89,8 +91,24 @@ public class Task extends TimeAuditBaseEntity {
         return detail.isOverdue() && !certification.isCertified();
     }
 
-    public boolean isHunter(User user) {
+    public boolean isAlreadyHunt(User user) {
         return huntings.stream()
                 .anyMatch(hunting -> hunting.isHunter(user));
+    }
+
+    private boolean isHuntable() {
+        return isFailed() && getHuntingCount() < calcHuntingCountLimit();
+    }
+
+    private boolean canHunt(User hunter) {
+        return challenge.canAccess(hunter) && !challenge.isOwner(hunter) && !isAlreadyHunt(hunter);
+    }
+
+    private Integer getHuntingCount() {
+        return huntings.size();
+    }
+
+    private Long calcHuntingCountLimit() {
+        return Math.round(challenge.getGroup().getNumOfMembers() * HUNTER_LIMIT_PER_TASK_RATIO);
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/challenge/Task.java
@@ -66,6 +66,10 @@ public class Task extends TimeAuditBaseEntity {
     }
 
     public Long calcHuntingReward() {
+        if (challenge.getTasks().isEmpty() || calcHuntingCountLimit() == 0) {
+            return 0L;
+        }
+
         return challenge.getDeposit().getInitialAmount() / challenge.getTasks().size() / calcHuntingCountLimit();
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
+++ b/src/main/java/sleppynavigators/studyupbackend/domain/group/GroupMember.java
@@ -54,7 +54,7 @@ public class GroupMember extends TimeAuditBaseEntity {
                 .filter(challenge -> !challenge.isOwner(user))
                 .flatMap(challenge -> challenge.getTasks().stream())
                 .filter(Task::isFailed)
-                .filter(task -> task.isHunter(user))
+                .filter(task -> task.isAlreadyHunt(user))
                 .count();
     }
 }

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
@@ -21,6 +21,7 @@ import sleppynavigators.studyupbackend.presentation.common.argument.SearchParam;
 import sleppynavigators.studyupbackend.presentation.group.dto.request.GroupSearch;
 import sleppynavigators.studyupbackend.presentation.group.dto.response.GroupListResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.FollowerListResponse;
+import sleppynavigators.studyupbackend.presentation.user.dto.response.HuntableTaskListResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserResponse;
 import sleppynavigators.studyupbackend.presentation.user.dto.response.UserTaskListResponse;
 
@@ -57,6 +58,15 @@ public class UserController {
     ) {
         Long userId = userPrincipal.userId();
         UserTaskListResponse response = userService.getTasks(userId, taskSearch);
+        return ResponseEntity.ok(new SuccessResponse<>(response));
+    }
+
+    @GetMapping("/me/tasks/bounties")
+    @Operation(summary = "유저의 헌팅 가능한 테스크 목록 조회", description = "유저가 헌팅할 수 있는 테스크 목록을 조회합니다.")
+    public ResponseEntity<SuccessResponse<HuntableTaskListResponse>> getHuntableTasks(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.userId();
+        HuntableTaskListResponse response = userService.getHuntableTasks(userId);
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/user/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 
-    @GetMapping("/me/tasks/bounties")
+    @GetMapping("/me/bounties")
     @Operation(summary = "유저의 헌팅 가능한 테스크 목록 조회", description = "유저가 헌팅할 수 있는 테스크 목록을 조회합니다.")
     public ResponseEntity<SuccessResponse<HuntableTaskListResponse>> getHuntableTasks(
             @AuthenticationPrincipal UserPrincipal userPrincipal) {

--- a/src/main/java/sleppynavigators/studyupbackend/presentation/user/dto/response/HuntableTaskListResponse.java
+++ b/src/main/java/sleppynavigators/studyupbackend/presentation/user/dto/response/HuntableTaskListResponse.java
@@ -1,0 +1,53 @@
+package sleppynavigators.studyupbackend.presentation.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import sleppynavigators.studyupbackend.domain.challenge.Task;
+import sleppynavigators.studyupbackend.presentation.challenge.dto.response.ChallengerDTO;
+import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskChallengeDTO;
+import sleppynavigators.studyupbackend.presentation.challenge.dto.response.TaskGroupDTO;
+
+@Schema(description = "헌팅 가능한 테스크 목록 응답")
+public record HuntableTaskListResponse(@NotNull @Valid List<HuntableTaskListItem> tasks) {
+
+    public static HuntableTaskListResponse fromEntities(List<Task> tasks) {
+        return new HuntableTaskListResponse(
+                tasks.stream()
+                        .map(HuntableTaskListItem::fromEntity)
+                        .toList());
+    }
+
+    @Schema(description = "헌팅 가능한 테스크")
+    public record HuntableTaskListItem(
+            @Schema(description = "테스크 ID", example = "1")
+            @NotNull Long id,
+
+            @Schema(description = "테스크 제목", example = "과제 제출하기")
+            @NotBlank String title,
+
+            @Schema(description = "헌팅 보상", example = "1000")
+            @NotNull Long reward,
+
+            @Schema(description = "챌린저 정보")
+            @NotNull @Valid ChallengerDTO challengerDetail,
+
+            @Schema(description = "테스크 챌린지 정보")
+            @NotNull @Valid TaskChallengeDTO challengeDetail,
+
+            @Schema(description = "테스크 그룹 정보")
+            @NotNull @Valid TaskGroupDTO groupDetail) {
+
+        public static HuntableTaskListItem fromEntity(Task task) {
+            return new HuntableTaskListItem(
+                    task.getId(),
+                    task.getDetail().getTitle(),
+                    task.calcHuntingReward(),
+                    ChallengerDTO.fromEntity(task.getChallenge()),
+                    TaskChallengeDTO.fromEntity(task),
+                    TaskGroupDTO.fromEntity(task));
+        }
+    }
+}

--- a/src/test/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeControllerTest.java
+++ b/src/test/java/sleppynavigators/studyupbackend/presentation/challenge/ChallengeControllerTest.java
@@ -244,8 +244,7 @@ public class ChallengeControllerTest extends RestAssuredBaseTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
         assertThat(response.jsonPath().getString("code")).isEqualTo(ErrorCode.FORBIDDEN_CONTENT.getCode());
-        assertThat(response.jsonPath().getString("message"))
-                .contains("Task is not failed");
+        assertThat(response.jsonPath().getString("message")).contains("Task is not huntable");
     }
 
     @Test
@@ -270,7 +269,6 @@ public class ChallengeControllerTest extends RestAssuredBaseTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
         assertThat(response.jsonPath().getString("code")).isEqualTo(ErrorCode.FORBIDDEN_CONTENT.getCode());
-        assertThat(response.jsonPath().getString("message"))
-                .contains("Hunting limit reached for this task");
+        assertThat(response.jsonPath().getString("message")).contains("Task is not huntable");
     }
 }


### PR DESCRIPTION
## 개요

> 3줄 이내로 정리해주세요. 그 이상을 넘어간다면 PR 을 나누는것을 고민해주세요

- 배경 : 사용자가 헌팅 가능한 테스크 목록을 한번에 조회할 API가 없음
- 변경사항 : API 추가
- 목표가 아닌 것 : 그 외 나머지

## 리뷰 시 참고 사항

> 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요

- "헌팅 가능한 테스크" 비즈니스를 Data Access Layer에서 결정짓기 어려웠습니다.
- 우선은 Application Layer까지 올린 후 계산하고 있습니다.
- 추후 필요하다면 반정규화를 고려해볼 수 있을듯 합니다.

## TODO

> 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요

없음

## References

> 사용된 레퍼런스에 대한 링크를 남겨주세요.

없음

## 체크리스트

- [x] PR 제목을 간결하게 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다
- [x] Bug fix, New feature, Breaking Change, Refactoring 등의 Label을 달았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 사냥할 수 있는 과제 목록을 조회하는 새로운 API 엔드포인트(`/users/me/bounties`)가 추가되었습니다.
  - 사냥 가능한 과제 목록을 반환하는 응답 DTO가 추가되었습니다.

- **버그 수정**
  - 사냥 실패 시 반환되는 에러 메시지가 보다 명확하게 "Task is not huntable"로 변경되었습니다.

- **테스트**
  - 사냥 가능한 과제 목록 조회 API의 성공 케이스에 대한 테스트가 추가되었습니다.

- **리팩터링**
  - 사냥 로직이 과제(Task) 중심으로 개선되어, 사냥 가능 여부와 보상 분배가 명확하게 분리되었습니다.
  - 사냥 인원 제한 등 사냥 관련 검증 로직이 과제 단위로 이동되고, 관련 메서드와 권한 체크가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->